### PR TITLE
Add PoC: mapeamento de palavras para sinais (JSON loader + integração)

### DIFF
--- a/scripts/dicionario_libras.json
+++ b/scripts/dicionario_libras.json
@@ -1,0 +1,10 @@
+{
+  "oi": ["mao_aberta_para_frente", "aceno_lateral", "sorriso_leve"],
+  "ola": ["mao_aberta_para_frente", "aceno_lateral", "sorriso_leve"],
+  "obrigado": ["mao_no_queixo", "move_para_frente", "olhar_grato"],
+  "agua": ["dedos_unidos_em_bico", "toca_boca", "move_para_baixo_duas_vezes"],
+  "comer": ["mao_fechada_polegar_na_boca", "movimento_mastigar"],
+  "sim": ["mao_fechada", "polegar_para_cima", "balancar_cabeca_sim"],
+  "nao": ["mao_aberta", "aceno_lateral_negativo", "balancar_cabeca_nao"],
+  "ajuda": ["mao_esquerda_aberta", "mao_direita_fecha_e_levanta"]
+}

--- a/scripts/integracao_reconhecimento.py
+++ b/scripts/integracao_reconhecimento.py
@@ -1,0 +1,18 @@
+from mapear_palavra_loader import DicionarioLibras
+
+# Exemplo de integração simples: reconhecimento de fala -> dicionário -> comandos
+
+def pipeline_exemplo(texto_reconhecido: str):
+    dicio = DicionarioLibras()
+    palavras = texto_reconhecido.split()
+    resultado = []
+    for p in palavras:
+        comandos = dicio.lookup(p)
+        resultado.append({"palavra": p, "comandos": comandos})
+    return resultado
+
+# Uso (integre com seu reconhecer_fala_do_microfone):
+# from reconhecimento_audio import reconhecer_fala_do_microfone
+# texto = reconhecer_fala_do_microfone()
+# if texto:
+#     print(pipeline_exemplo(texto))

--- a/scripts/mapear_palavra_loader.py
+++ b/scripts/mapear_palavra_loader.py
@@ -1,0 +1,43 @@
+import json
+import unicodedata
+from pathlib import Path
+
+DEFAULT_PATH = Path(__file__).parent / "dicionario_libras.json"
+
+def remover_acentos(texto: str) -> str:
+    texto_nfkd = unicodedata.normalize("NFKD", texto)
+    return "".join([c for c in texto_nfkd if not unicodedata.combining(c)])
+
+def normalizar_texto(texto: str) -> str:
+    texto = texto.strip().lower()
+    texto = remover_acentos(texto)
+    return texto
+
+class DicionarioLibras:
+    def __init__(self, path: Path = DEFAULT_PATH):
+        self.path = path
+        self._carregar()
+
+    def _carregar(self):
+        if not self.path.exists():
+            self.data = {}
+        else:
+            with open(self.path, "r", encoding="utf-8") as f:
+                self.data = json.load(f)
+
+    def lookup(self, palavra: str):
+        chave = normalizar_texto(palavra)
+        if chave in self.data:
+            return self.data[chave]
+        if chave.endswith("s") and chave[:-1] in self.data:
+            return self.data[chave[:-1]]
+        return ["sinal_desconhecido"]
+
+    def adicionar(self, palavra: str, comandos):
+        chave = normalizar_texto(palavra)
+        self.data[chave] = comandos
+        self._salvar()
+
+    def _salvar(self):
+        with open(self.path, "w", encoding="utf-8") as f:
+            json.dump(self.data, f, ensure_ascii=False, indent=2)

--- a/scripts/mapear_palavra_para_sinal.py
+++ b/scripts/mapear_palavra_para_sinal.py
@@ -1,0 +1,38 @@
+# mapeamento conceitual simples: palavra -> comandos de sinal
+# Use este arquivo como exemplo/PoC; em produção substitua por DB/ML.
+
+def mapear_palavra_para_sinal(palavra):
+    # Dicionário conceitual de palavras para "comandos de sinal"
+    # Na vida real, isto seria um banco de dados com movimentos, expressões, variantes, tempo, etc.
+    dicionario_libras_conceitual = {
+        "oi": ["mao_aberta_para_frente", "aceno_lateral", "sorriso_leve"],
+        "olá": ["mao_aberta_para_frente", "aceno_lateral", "sorriso_leve"],
+        "obrigado": ["mao_no_queixo", "move_para_frente", "olhar_grato"],
+        "água": ["dedos_unidos_em_bico", "toca_boca", "move_para_baixo_duas_vezes"],
+        "comer": ["mao_fechada_polegar_na_boca", "movimento_mastigar"],
+        "sim": ["mao_fechada", "polegar_para_cima", "balancar_cabeca_sim"],
+        "não": ["mao_aberta", "aceno_lateral_negativo", "balancar_cabeca_nao"],
+        "ajuda": ["mao_esquerda_aberta", "mao_direita_fecha_e_levanta"],
+        # ... muitas outras palavras e frases
+    }
+
+    # Normaliza entrada (minúsculas). Em etapas posteriores, adicionar normalização de acentos/stopwords.
+    palavra_min = palavra.lower()
+
+    if palavra_min in dicionario_libras_conceitual:
+        comandos_sinal = dicionario_libras_conceitual[palavra_min]
+        print(f"Comandos de sinal para '{palavra}': {comandos_sinal}")
+        return comandos_sinal
+    else:
+        print(f"Sinal para '{palavra}' não encontrado no dicionário conceitual.")
+        # Em um app real, usar PLN/IA para decompor a frase ou gerar sinal aproximado.
+        return ["sinal_desconhecido"]
+
+# Testes rápidos
+if __name__ == "__main__":
+    print("\n--- Testando Mapeamento de Sinais ---")
+    mapear_palavra_para_sinal("Olá")
+    mapear_palavra_para_sinal("Obrigado")
+    mapear_palavra_para_sinal("cachorro")  # Esta palavra não está no dicionário
+    mapear_palavra_para_sinal("Água")
+    mapear_palavra_para_sinal("sim")


### PR DESCRIPTION
- Resumo
    - Adiciona PoC para mapeamento palavra -> comandos de sinal.
    - Introduce dicionário JSON e loader com normalização (remoção de acentos).
    - Adiciona script de integração simples (reconhecimento de fala -> dicionário).

-  Checklist
    - Revisar compatibilidade com Python 3.10+
    - Testar integração local: reconhecimento de fala -> pipeline_exemplo
    - Validar conteúdo do dicionário JSON
    - Adicionar testes automatizados

-Arquivos incluídos:
    - scripts/mapear_palavra_para_sinal.py
    - scripts/dicionario_libras.json
    - scripts/mapear_palavra_loader.py
    - scripts/integracao_reconhecimento.py